### PR TITLE
Update to GNOME 47 runtime

### DIFF
--- a/0001-demo-Update-categories-keywords-in-the-desktop-file.patch
+++ b/0001-demo-Update-categories-keywords-in-the-desktop-file.patch
@@ -1,0 +1,27 @@
+From 4afab609f5aef76c0bee7963a8f823db2e9e15ac Mon Sep 17 00:00:00 2001
+From: Bilal Elmoussaoui <belmouss@redhat.com>
+Date: Mon, 1 Jan 2024 16:43:09 +0100
+Subject: [PATCH] demo: Update categories/keywords in the desktop file
+
+---
+ data/com.belmoussaoui.ashpd.demo.desktop.in.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/data/com.belmoussaoui.ashpd.demo.desktop.in.in b/data/com.belmoussaoui.ashpd.demo.desktop.in.in
+index f7ab6a145..6a11ecd2b 100644
+--- a/data/com.belmoussaoui.ashpd.demo.desktop.in.in
++++ b/data/com.belmoussaoui.ashpd.demo.desktop.in.in
+@@ -4,8 +4,8 @@ Comment=Play with portals
+ Type=Application
+ Exec=ashpd-demo
+ Terminal=false
+-Categories=GNOME;GTK;
+-Keywords=Gnome;GTK;
++Categories=Utility;GNOME;GTK;
++Keywords=Gnome;GTK;ASHPD;Portals;Demo;
+ # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+ Icon=@icon@
+ StartupNotify=true
+-- 
+2.47.0
+

--- a/com.belmoussaoui.ashpd.demo.json
+++ b/com.belmoussaoui.ashpd.demo.json
@@ -49,6 +49,10 @@
                     "type": "archive",
                     "url": "https://github.com/bilelmoussaoui/ashpd/releases/download/0.4.1-demo/ashpd-demo-0.4.1.tar.xz",
                     "sha256": "e3d356db030b35993d5ae158edf5ff3fd2be9ac4e874f8c56df6d4f8f2a29793"
+                },
+                {
+                    "type": "patch",
+                    "path": "0001-demo-Update-categories-keywords-in-the-desktop-file.patch"
                 }
             ]
         }

--- a/com.belmoussaoui.ashpd.demo.json
+++ b/com.belmoussaoui.ashpd.demo.json
@@ -1,11 +1,11 @@
 {
     "id": "com.belmoussaoui.ashpd.demo",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "45",
+    "runtime-version": "47",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable",
-        "org.freedesktop.Sdk.Extension.llvm16"
+        "org.freedesktop.Sdk.Extension.llvm18"
     ],
     "command": "ashpd-demo",
     "finish-args": [
@@ -19,23 +19,25 @@
     ],
     "build-options": {
         "append-path": "/usr/lib/sdk/rust-stable/bin",
-        "prepend-path": "/usr/lib/sdk/llvm16/bin",
-        "prepend-ld-library-path": "/usr/lib/sdk/llvm16/lib"
+        "prepend-path": "/usr/lib/sdk/llvm18/bin",
+        "prepend-ld-library-path": "/usr/lib/sdk/llvm18/lib"
     },
     "modules": [
         {
             "name": "libshumate",
             "buildsystem": "meson",
             "config-opts": [
+                "-Ddemos=false",
+                "-Dvector_renderer=false",
                 "-Dgir=false",
                 "-Dvapi=false",
                 "-Dgtk_doc=false"
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/libshumate/",
-                    "tag": "1.0.5"
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/libshumate/1.3/libshumate-1.3.0.tar.xz",
+                    "sha256": "8227a6e8281cde12232894fef83760d44fa66b39ef033c61ed934a86c6dc75d4"
                 }
             ]
         },


### PR DESCRIPTION
The `vector_renderer=false` option is needed to avoid adding a bunch of dependencies.